### PR TITLE
⚡ Optimize GitHubClient by reusing OkHttpClient

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/lefthook/GitHubClient.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/lefthook/GitHubClient.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.lefthook
 

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/lefthook/GitHubClient.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/lefthook/GitHubClient.groovy
@@ -8,6 +8,10 @@ import org.apache.commons.io.FileUtils
 
 public class GitHubClient {
 
+    private static final OkHttpClient okclient = new OkHttpClient()
+            .newBuilder()
+            .build()
+
     static def resolve = { String repo, OS.Arch arch, OS.Family os, String version ->
         def params = [
             arch: arch,
@@ -51,9 +55,6 @@ public class GitHubClient {
 
     static def getRelease = { repo, version ->
  
-        OkHttpClient okclient = new OkHttpClient()
-            .newBuilder()
-            .build()
         MediaType mediaType = MediaType.parse("application/vnd.github+json")
         //TODO allow full URL
         


### PR DESCRIPTION
*   💡 **What:** Moved `OkHttpClient` instantiation from the `getRelease` closure to a `static final` field in the `GitHubClient` class.
*   🎯 **Why:** Creating a new `OkHttpClient` for each request is inefficient as it prevents connection pooling and reuse of thread pools. Reusing a single instance improves performance and resource usage.
*   📊 **Measured Improvement:** Verified functionality with existing tests. Performance improvement is theoretical based on `OkHttpClient` best practices (avoiding repeated expensive object creation and resource allocation).


---
*PR created automatically by Jules for task [1846595227912094550](https://jules.google.com/task/1846595227912094550) started by @boxheed*